### PR TITLE
Fix for Rails 2: code was injected even if query reviewer was disabled

### DIFF
--- a/lib/query_reviewer/rails.rb
+++ b/lib/query_reviewer/rails.rb
@@ -33,5 +33,5 @@ if defined?(Rails::Railtie)
 else # Rails 2
   QueryReviewer.load_configuration
 
-  QueryReviewer.inject_reviewer
+  QueryReviewer.inject_reviewer if QueryReviewer.enabled?
 end


### PR DESCRIPTION
Code was right in the Rails 3 side, but in the "else" for Rails 2 a condition was missing. This was causing query reviewer html showing in production sites.
