### PR TITLE
Handle Arel::UpdateManager instances as sql.

### DIFF
--- a/lib/query_reviewer/sql_query.rb
+++ b/lib/query_reviewer/sql_query.rb
@@ -116,6 +116,7 @@ module QueryReviewer
 
     def self.sanitize_strings_and_numbers_from_sql(sql)
       new_sql = sql.clone
+      new_sql = new_sql.to_sql if new_sql.respond_to?(:to_sql)
       new_sql.gsub!(/\b\d+\b/, "N")
       new_sql.gsub!(/\b0x[0-9A-Fa-f]+\b/, "N")
       new_sql.gsub!(/''/, "'S'")

--- a/lib/query_reviewer/views/query_review_box_helper.rb
+++ b/lib/query_reviewer/views/query_review_box_helper.rb
@@ -20,6 +20,7 @@ module QueryReviewer
       end
 
       def syntax_highlighted_sql(sql)
+        sql = sql.to_sql if sql.respond_to?(:to_sql)
         if QueryReviewer::CONFIGURATION["uv"]
           uv_out = Uv.parse(sql, "xhtml", "sql_rails", false, "blackboard")
           uv_out.gsub("<pre class=\"blackboard\">", "<code class=\"sql\">").gsub("</pre>", "</code>")


### PR DESCRIPTION
Fix for issue #9: Exception when saving data on Rails 3.1

Update to handle the passed instance of Arel::UpdateManager in Rails 3.1, instead of a sql query string.

Those where the only two places it was generating an error, sometimes it gets a string others an Arel::UpdateManager instance.
