### PR TITLE
Rails 3.1+ support

### DIFF
--- a/lib/query_reviewer.rb
+++ b/lib/query_reviewer.rb
@@ -49,6 +49,15 @@ module QueryReviewer
   def self.enabled?
     CONFIGURATION["enabled"]
   end
+  
+  def self.safe_log(&block)
+    if Rails::VERSION::STRING.to_f >= 3.1
+      @logger.quietly { yield }
+    else
+      @logger.silence { yield }
+    end
+  end
+  
 end
 
 # Rails Integration

--- a/lib/query_reviewer/mysql_adapter_extensions.rb
+++ b/lib/query_reviewer/mysql_adapter_extensions.rb
@@ -39,7 +39,7 @@ module QueryReviewer
     
     def select_with_review(sql, *args)
       sql.gsub!(/^SELECT /i, "SELECT SQL_NO_CACHE ") if QueryReviewer::CONFIGURATION["disable_sql_cache"]
-      @logger.silence { execute("SET PROFILING=1") } if QueryReviewer::CONFIGURATION["profiling"]
+      @logger.quietly { execute("SET PROFILING=1") } if QueryReviewer::CONFIGURATION["profiling"]
       t1 = Time.now
       query_results = select_without_review(sql, *args)
       t2 = Time.now
@@ -50,19 +50,19 @@ module QueryReviewer
 
         if use_profiling
           t5 = Time.now
-          @logger.silence { execute("SET PROFILING=1") }
+          @logger.quietly { execute("SET PROFILING=1") }
           t3 = Time.now
           select_without_review(sql, *args)
           t4 = Time.now
-          profile = @logger.silence { select_without_review("SHOW PROFILE ALL", *args) }
-          @logger.silence { execute("SET PROFILING=0") }
+          profile = @logger.quietly { select_without_review("SHOW PROFILE ALL", *args) }
+          @logger.quietly { execute("SET PROFILING=0") }
           t6 = Time.now
           Thread.current["queries"].overhead_time += t6 - t5
         else
           profile = nil
         end
 
-        cols = @logger.silence do
+        cols = @logger.quietly do
           select_without_review("explain #{sql}", *args)
         end
 

--- a/lib/query_reviewer/mysql_adapter_extensions.rb
+++ b/lib/query_reviewer/mysql_adapter_extensions.rb
@@ -39,7 +39,7 @@ module QueryReviewer
     
     def select_with_review(sql, *args)
       sql.gsub!(/^SELECT /i, "SELECT SQL_NO_CACHE ") if QueryReviewer::CONFIGURATION["disable_sql_cache"]
-      @logger.quietly { execute("SET PROFILING=1") } if QueryReviewer::CONFIGURATION["profiling"]
+      QueryReviewer.safe_log { execute("SET PROFILING=1") } if QueryReviewer::CONFIGURATION["profiling"]
       t1 = Time.now
       query_results = select_without_review(sql, *args)
       t2 = Time.now
@@ -50,19 +50,19 @@ module QueryReviewer
 
         if use_profiling
           t5 = Time.now
-          @logger.quietly { execute("SET PROFILING=1") }
+          QueryReviewer.safe_log { execute("SET PROFILING=1") }
           t3 = Time.now
           select_without_review(sql, *args)
           t4 = Time.now
-          profile = @logger.quietly { select_without_review("SHOW PROFILE ALL", *args) }
-          @logger.quietly { execute("SET PROFILING=0") }
+          profile = QueryReviewer.safe_log { select_without_review("SHOW PROFILE ALL", *args) }
+          QueryReviewer.safe_log { execute("SET PROFILING=0") }
           t6 = Time.now
           Thread.current["queries"].overhead_time += t6 - t5
         else
           profile = nil
         end
 
-        cols = @logger.quietly do
+        cols = QueryReviewer.safe_log do
           select_without_review("explain #{sql}", *args)
         end
 

--- a/query_reviewer.gemspec
+++ b/query_reviewer.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'query_reviewer'
-  s.version = '0.1.3'
+  s.version = '0.1.4'
   s.author = 'dsboulder, nesquena'
   s.email = 'nesquena' + '@' + 'gmail.com'
   s.homepage = 'https://github.com/nesquena/query_reviewer'


### PR DESCRIPTION
QueryReviewer doesn't work in Rails 3.1+, I think because silence was deprecated. I changed it to quietly which fixes the issue for me.
