### PR TITLE
dynamically enabled per request based on session

### DIFF
--- a/lib/query_reviewer/controller_extensions.rb
+++ b/lib/query_reviewer/controller_extensions.rb
@@ -30,6 +30,8 @@ module QueryReviewer
     end
 
     def add_query_output_to_view(total_time)
+      return unless Thread.current["query_reviewer_enabled"]
+
       if request.xhr?
         if cookies["query_review_enabled"]
           if !response.content_type || response.content_type.include?("text/html")
@@ -48,7 +50,9 @@ module QueryReviewer
     end
 
     def perform_action_with_query_review(*args)
-      Thread.current["query_reviewer_enabled"] = cookies["query_review_enabled"]
+      Thread.current["query_reviewer_enabled"] = (CONFIGURATION["enabled"] == true               and cookies["query_review_enabled"]) ||
+                                                 (CONFIGURATION["enabled"] == "based_on_session" and session["query_review_enabled"])
+
       t1 = Time.now
       r = defined?(Rails::Railtie) ? process_action_without_query_review(*args) : perform_action_without_query_review(*args)
       t2 = Time.now


### PR DESCRIPTION
WIth this commit, the application may set "enabled" to "based_on_session" in the config file.  Then, query_reviewer acts as if "enabled" is true or false based on this session value.

The application would need an action to toggle this session variable, presumably available to only system administrators.  Here's an example:

``` ruby
def toggle_query_reviewer
  session["query_review_enabled"] = !session["query_review_enabled"]
  redirect_to root_url
end
```

Hopefully, you find these changes minor and straightforward.  Let me know you see any issues with this.

Thanks!

-Mike
