### PR TITLE
query_review_output shows no queries unless inject_view enabled

### DIFF
--- a/lib/query_reviewer/controller_extensions.rb
+++ b/lib/query_reviewer/controller_extensions.rb
@@ -62,6 +62,9 @@ module QueryReviewer
     alias_method :process_action_with_query_review, :perform_action_with_query_review
 
     def process_with_query_review(*args) #:nodoc:
+      Thread.current["query_reviewer_enabled"] = (CONFIGURATION["enabled"] == true               and cookies["query_review_enabled"]) ||
+                                                 (CONFIGURATION["enabled"] == "based_on_session" and session["query_review_enabled"])
+
       Thread.current["queries"] = SqlQueryCollection.new
       process_without_query_review(*args)
     end


### PR DESCRIPTION
This patch fixes the issue where no queries are reviewed unless inject_view is enabled.  Disabling inject_view is useful in cases where inject_view injects output into files sent with send_file (another bug which should probably be fixed on its own).
