### PR TITLE
0.1.7 fix

### DIFF
--- a/lib/query_reviewer/controller_extensions.rb
+++ b/lib/query_reviewer/controller_extensions.rb
@@ -48,7 +48,7 @@ module QueryReviewer
     end
 
     def perform_action_with_query_review(*args)
-      Thread.current["query_reviewer_enabled"] = (CONFIGURATION["enabled"] == true and cookies["query_review_enabled"]) || (CONFIGURATION["enabled"] == "based_on_session" and session["query_review_enabled"])
+      Thread.current["query_reviewer_enabled"] = query_reviewer_output_enabled?
 
       t1 = Time.now
       r = defined?(Rails::Railtie) ? process_action_without_query_review(*args) : perform_action_without_query_review(*args)
@@ -61,6 +61,13 @@ module QueryReviewer
     def process_with_query_review(*args) #:nodoc:
       Thread.current["queries"] = SqlQueryCollection.new
       process_without_query_review(*args)
+    end
+
+    # @return [Boolean].  Returns whether or not the user has indicated that query_reviewer is enabled
+    def query_reviewer_output_enabled?
+      cookie_enabled = (CONFIGURATION["enabled"] == true and cookies["query_review_enabled"])
+      session_enabled = (CONFIGURATION["enabled"] == "based_on_session" and session["query_review_enabled"])
+      return cookie_enabled || session_enabled
     end
   end
 end

--- a/lib/query_reviewer/controller_extensions.rb
+++ b/lib/query_reviewer/controller_extensions.rb
@@ -48,8 +48,7 @@ module QueryReviewer
     end
 
     def perform_action_with_query_review(*args)
-      return unless (CONFIGURATION["enabled"] == true               and cookies["query_review_enabled"]) ||
-                    (CONFIGURATION["enabled"] == "based_on_session" and session["query_review_enabled"])
+      Thread.current["query_reviewer_enabled"] = (CONFIGURATION["enabled"] == true and cookies["query_review_enabled"]) || (CONFIGURATION["enabled"] == "based_on_session" and session["query_review_enabled"])
 
       t1 = Time.now
       r = defined?(Rails::Railtie) ? process_action_without_query_review(*args) : perform_action_without_query_review(*args)

--- a/lib/query_reviewer/controller_extensions.rb
+++ b/lib/query_reviewer/controller_extensions.rb
@@ -63,7 +63,7 @@ module QueryReviewer
       process_without_query_review(*args)
     end
 
-    # @return [Boolean].  Returns whether or not the user has indicated that query_reviewer is enabled
+    # @return [Boolean].  Returns whether or not the user has indicated that query_reviewer output is enabled
     def query_reviewer_output_enabled?
       cookie_enabled = (CONFIGURATION["enabled"] == true and cookies["query_review_enabled"])
       session_enabled = (CONFIGURATION["enabled"] == "based_on_session" and session["query_review_enabled"])


### PR DESCRIPTION
Hello there!

First off, thank you so much for maintaining this amazingly helpful gem!  It has proven it's worth time and time again with my work at @sifteo as well as some of my personal projects.  

That being said, I noticed today that our development environment experienced some regressions due to some recent changes of `query_reviewer`.  More specificly, the changeset between `0.1.6` and `0.1.7`.  

After some debugging, I was able to determine that [this particular commit](https://github.com/nesquena/query_reviewer/commit/352d2db3afe1e88f37264bc50212e0fc6fcd3ec5) introduced a regression where `Thread.current["query_reviewer_enabled"]` was not being set, which prevented queries from being inserted into `Thread.current["queries"]`, as described [here](https://github.com/nesquena/query_reviewer/blob/master/lib/query_reviewer/mysql_adapter_extensions.rb#L80).

Another regression also introduced [not being able to render controller actions](http://stackoverflow.com/questions/14763584/rails-3-1-10-upgrade-results-in-consistent-get-miss) for users that did not set the cookie that allows query_reviewer to work its magic.

This set of commits aims to be the least-amount-of-work to get back to a fully functional state, though for all intents and purposes, it is more-or-less a revert to a previous state.

Thanks!
