### PR TITLE
Update README.md - remove repo specification from README.md's Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# QueryReviewer #
+    # QueryReviewer #
 
 ## Introduction ##
 
@@ -49,7 +49,7 @@ All you have to do is install it into your Rails 2 or 3 project.
 Right now if you use bundler, simply add this to your Gemfile:
 
     # Gemfile
-    gem "query_reviewer", :git => "git://github.com/nesquena/query_reviewer.git"
+    gem "query_reviewer"
 
 If you are not using bundler, you might want to [start using it](http://gembundler.com/rails23.html). You can also install this as a plugin:
 


### PR DESCRIPTION
According to https://rubygems.org/gems/query_reviewer/versions/0.1.8, there's no need to specify the repo in Gemfile.
