### PR TITLE
Don't warn on impossible where

### DIFF
--- a/lib/query_reviewer/mysql_analyzer.rb
+++ b/lib/query_reviewer/mysql_analyzer.rb
@@ -34,7 +34,7 @@ module QueryReviewer
     def analyze_key!
       if self.key == "const"
         praise "Way to go!"
-      elsif self.key.blank? && !self.extra.include?("select tables optimized away")
+      elsif self.key.blank? && !self.extra.include?("select tables optimized away") && !self.extra.include?("impossible where noticed after reading const tables")
         warn :severity => 6, :field => "key", :desc => "No index was used here. In this case, that meant scanning #{self.rows} rows."
       end
     end


### PR DESCRIPTION
MySQL will sometimes return an explain row with a blank `key` column but with `impossible where noticed after reading const tables` in the `extra` column.

This currently produces a warning, but it's harmless so it should be ignored.
