### PR TITLE
Fix issue #31: Test response @body instead of response.body

### DIFF
--- a/lib/query_reviewer/controller_extensions.rb
+++ b/lib/query_reviewer/controller_extensions.rb
@@ -39,7 +39,8 @@ module QueryReviewer
           end
         end
       else
-        if response.body.is_a?(String) && response.body.match(/<\/body>/i)
+        if !response.instance_eval{ @body.is_a?(File) || @body.is_a?(Enumerator) } &&
+             response.body.is_a?(String) && response.body.match(/<\/body>/i)
           idx = (response.body =~ /<\/body>/i)
           html = query_review_output(false, total_time)
           response.body = response.body.insert(idx, html)


### PR DESCRIPTION
A quick test on Rails 3.0 shows that this works.  Of course using instance_eval is fragile and this might break in later versions of Rails.
